### PR TITLE
ci: bump checkout/setup-java to v5 (Node 24)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'


### PR DESCRIPTION
`actions/checkout@v4` and `actions/setup-java@v4` run on the deprecated Node.js 20 runtime (GitHub is forcing them onto Node 24 with a warning). Bump both to `@v5` (Node 24) in `build.yml` and `publish.yml` to clear the warning. No behavior change.